### PR TITLE
test: add CLI command tests to reach 78% coverage

### DIFF
--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRunExplain(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runExplain(nil, nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runExplain() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify key sections are present
+	expectedStrings := []string{
+		"# Smoke - Agent Social Feed",
+		"## Purpose",
+		"## Commands",
+		"smoke post",
+		"smoke read",
+		"smoke reply",
+		"## Identity",
+		"## When to Post",
+		"## Storage",
+		"feed.jsonl",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("runExplain() output missing %q", expected)
+		}
+	}
+}
+
+func TestExplainCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "explain" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("explain command not registered with root")
+	}
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInitDryRun(t *testing.T) {
+	// Set up temp directory for config
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Create .claude dir for hint check
+	claudeDir := filepath.Join(tempDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	// Reset flags
+	initForce = false
+	initDryRun = true
+	defer func() {
+		initDryRun = false
+	}()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInit(nil, nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runInit() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify dry-run output
+	if !strings.Contains(output, "[dry-run]") {
+		t.Error("runInit() dry-run output should contain [dry-run] prefix")
+	}
+	if !strings.Contains(output, "Would") {
+		t.Error("runInit() dry-run output should contain 'Would' actions")
+	}
+
+	// Verify nothing was actually created
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	if _, err := os.Stat(configDir); err == nil {
+		t.Error("runInit() dry-run should not create config directory")
+	}
+}
+
+func TestRunInitFresh(t *testing.T) {
+	// Set up temp directory for config
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Create .claude dir for hint check
+	claudeDir := filepath.Join(tempDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	// Reset flags
+	initForce = false
+	initDryRun = false
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInit(nil, nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runInit() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify output
+	if !strings.Contains(output, "Initialized smoke") {
+		t.Error("runInit() output should contain 'Initialized smoke'")
+	}
+
+	// Verify files were created
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		t.Error("runInit() should create config directory")
+	}
+
+	feedPath := filepath.Join(configDir, "feed.jsonl")
+	if _, err := os.Stat(feedPath); os.IsNotExist(err) {
+		t.Error("runInit() should create feed file")
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("runInit() should create config file")
+	}
+}
+
+func TestRunInitAlreadyInitialized(t *testing.T) {
+	// Set up temp directory with existing smoke config
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Create existing config
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	os.MkdirAll(configDir, 0755)
+	feedPath := filepath.Join(configDir, "feed.jsonl")
+	os.WriteFile(feedPath, []byte{}, 0644)
+
+	// Reset flags
+	initForce = false
+	initDryRun = false
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInit(nil, nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runInit() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify already initialized message
+	if !strings.Contains(output, "already initialized") {
+		t.Error("runInit() should indicate already initialized")
+	}
+	if !strings.Contains(output, "--force") {
+		t.Error("runInit() should mention --force option")
+	}
+}
+
+func TestRunInitForce(t *testing.T) {
+	// Set up temp directory with existing smoke config
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Create existing config
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	os.MkdirAll(configDir, 0755)
+	feedPath := filepath.Join(configDir, "feed.jsonl")
+	os.WriteFile(feedPath, []byte("old content"), 0644)
+
+	// Create .claude dir for hint check
+	claudeDir := filepath.Join(tempDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	// Set force flag
+	initForce = true
+	initDryRun = false
+	defer func() {
+		initForce = false
+	}()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runInit(nil, nil)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runInit() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify reinitialized
+	if !strings.Contains(output, "Initialized smoke") {
+		t.Error("runInit() with --force should reinitialize")
+	}
+}
+
+func TestInitCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "init" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("init command not registered with root")
+	}
+}
+
+func TestInitFlagsRegistered(t *testing.T) {
+	forceFlag := initCmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Error("--force flag not registered")
+	}
+
+	dryRunFlag := initCmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Error("--dry-run flag not registered")
+	}
+}

--- a/internal/cli/post_test.go
+++ b/internal/cli/post_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupSmokeEnv(t *testing.T) (cleanup func()) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origBDActor := os.Getenv("BD_ACTOR")
+	origSmokeAuthor := os.Getenv("SMOKE_AUTHOR")
+
+	os.Setenv("HOME", tempDir)
+	os.Setenv("BD_ACTOR", "testbot@testproject")
+	os.Setenv("SMOKE_AUTHOR", "")
+
+	// Create smoke config
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	os.MkdirAll(configDir, 0755)
+	feedPath := filepath.Join(configDir, "feed.jsonl")
+	os.WriteFile(feedPath, []byte{}, 0644)
+
+	return func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("BD_ACTOR", origBDActor)
+		os.Setenv("SMOKE_AUTHOR", origSmokeAuthor)
+	}
+}
+
+func TestRunPost(t *testing.T) {
+	cleanup := setupSmokeEnv(t)
+	defer cleanup()
+
+	// Reset flag
+	postAuthor = ""
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runPost(nil, []string{"test message"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runPost() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify output contains confirmation
+	if !strings.Contains(output, "smk-") {
+		t.Error("runPost() output should contain post ID (smk-*)")
+	}
+}
+
+func TestRunPostWithAuthor(t *testing.T) {
+	cleanup := setupSmokeEnv(t)
+	defer cleanup()
+
+	// Set custom author
+	postAuthor = "custom-author"
+	defer func() { postAuthor = "" }()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runPost(nil, []string{"test with custom author"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runPost() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Output shows "Posted smk-xxx" confirmation
+	if !strings.Contains(output, "Posted smk-") {
+		t.Error("runPost() output should contain post confirmation")
+	}
+}
+
+func TestRunPostNotInitialized(t *testing.T) {
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Don't create smoke config
+
+	err := runPost(nil, []string{"test message"})
+
+	if err == nil {
+		t.Error("runPost() should return error when not initialized")
+	}
+}
+
+func TestRunPostMessageTooLong(t *testing.T) {
+	cleanup := setupSmokeEnv(t)
+	defer cleanup()
+
+	// Reset flag
+	postAuthor = ""
+
+	// Create a message longer than 280 chars
+	longMessage := strings.Repeat("a", 300)
+
+	err := runPost(nil, []string{longMessage})
+
+	if err == nil {
+		t.Error("runPost() should return error for message > 280 chars")
+	}
+	if !strings.Contains(err.Error(), "280") {
+		t.Errorf("error should mention 280 char limit, got: %v", err)
+	}
+}
+
+func TestPostCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "post <message>" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("post command not registered with root")
+	}
+}
+
+func TestPostFlagsRegistered(t *testing.T) {
+	authorFlag := postCmd.Flags().Lookup("author")
+	if authorFlag == nil {
+		t.Error("--author flag not registered")
+	}
+}

--- a/internal/cli/reply_test.go
+++ b/internal/cli/reply_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dreamiurg/smoke/internal/feed"
+)
+
+func setupSmokeEnvWithPost(t *testing.T) (postID string, cleanup func()) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origBDActor := os.Getenv("BD_ACTOR")
+	origSmokeAuthor := os.Getenv("SMOKE_AUTHOR")
+
+	os.Setenv("HOME", tempDir)
+	os.Setenv("BD_ACTOR", "testbot@testproject")
+	os.Setenv("SMOKE_AUTHOR", "")
+
+	// Create smoke config with a post
+	configDir := filepath.Join(tempDir, ".config", "smoke")
+	os.MkdirAll(configDir, 0755)
+	feedPath := filepath.Join(configDir, "feed.jsonl")
+
+	// Create a test post
+	post := feed.Post{
+		ID:        "smk-abc123",
+		Author:    "testbot@testproject",
+		Project:   "testproject",
+		Suffix:    "test-suffix",
+		Content:   "test post",
+		CreatedAt: "2026-01-31T12:00:00Z",
+	}
+	data, _ := json.Marshal(post)
+	os.WriteFile(feedPath, append(data, '\n'), 0644)
+
+	return post.ID, func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("BD_ACTOR", origBDActor)
+		os.Setenv("SMOKE_AUTHOR", origSmokeAuthor)
+	}
+}
+
+func TestRunReply(t *testing.T) {
+	postID, cleanup := setupSmokeEnvWithPost(t)
+	defer cleanup()
+
+	// Reset flag
+	replyAuthor = ""
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runReply(nil, []string{postID, "test reply"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runReply() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify output contains reply confirmation
+	if !strings.Contains(output, "smk-") {
+		t.Error("runReply() output should contain reply ID (smk-*)")
+	}
+}
+
+func TestRunReplyWithAuthor(t *testing.T) {
+	postID, cleanup := setupSmokeEnvWithPost(t)
+	defer cleanup()
+
+	// Set custom author
+	replyAuthor = "custom-replier"
+	defer func() { replyAuthor = "" }()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runReply(nil, []string{postID, "reply with custom author"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Errorf("runReply() error = %v", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Output shows "Replied smk-xxx -> smk-yyy" confirmation
+	if !strings.Contains(output, "Replied smk-") {
+		t.Error("runReply() output should contain reply confirmation")
+	}
+}
+
+func TestRunReplyNotInitialized(t *testing.T) {
+	tempDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Don't create smoke config
+
+	err := runReply(nil, []string{"smk-abc123", "test reply"})
+
+	if err == nil {
+		t.Error("runReply() should return error when not initialized")
+	}
+}
+
+func TestRunReplyInvalidPostID(t *testing.T) {
+	_, cleanup := setupSmokeEnvWithPost(t)
+	defer cleanup()
+
+	err := runReply(nil, []string{"invalid-id", "test reply"})
+
+	if err == nil {
+		t.Error("runReply() should return error for invalid post ID format")
+	}
+	if !strings.Contains(err.Error(), "invalid post ID") {
+		t.Errorf("error should mention invalid post ID, got: %v", err)
+	}
+}
+
+func TestRunReplyPostNotFound(t *testing.T) {
+	_, cleanup := setupSmokeEnvWithPost(t)
+	defer cleanup()
+
+	err := runReply(nil, []string{"smk-notfnd", "test reply"})
+
+	if err == nil {
+		t.Error("runReply() should return error when parent post not found")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention post not found, got: %v", err)
+	}
+}
+
+func TestRunReplyMessageTooLong(t *testing.T) {
+	postID, cleanup := setupSmokeEnvWithPost(t)
+	defer cleanup()
+
+	// Reset flag
+	replyAuthor = ""
+
+	// Create a message longer than 280 chars
+	longMessage := strings.Repeat("a", 300)
+
+	err := runReply(nil, []string{postID, longMessage})
+
+	if err == nil {
+		t.Error("runReply() should return error for message > 280 chars")
+	}
+	if !strings.Contains(err.Error(), "280") {
+		t.Errorf("error should mention 280 char limit, got: %v", err)
+	}
+}
+
+func TestReplyCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "reply <post-id> <message>" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("reply command not registered with root")
+	}
+}
+
+func TestReplyFlagsRegistered(t *testing.T) {
+	authorFlag := replyCmd.Flags().Lookup("author")
+	if authorFlag == nil {
+		t.Error("--author flag not registered")
+	}
+}


### PR DESCRIPTION
## Summary

- Add tests for CLI commands: explain, init, post, reply
- CLI coverage: 46.5% → 70.5%
- Overall coverage: 67.2% → 78.0%

## Test plan

- [x] All tests pass locally (`go test -race ./...`)
- [x] Coverage threshold met (78% > 70%)
- [ ] CI passes (note: golangci-lint v2 required, local system has v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)