### PR TITLE
chore: add pre-commit hook to prevent commits on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml


### PR DESCRIPTION
## Summary

- Add `no-commit-to-branch` hook to prevent direct commits to main
- Forces all changes to go through PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)