### PR TITLE
chore: move tests to pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,11 @@ repos:
         types: [go]
         pass_filenames: false
 
+      # Tests run on pre-push, not pre-commit (see below)
       - id: go-test
         name: go test
         entry: bash -c 'go test -race ./...'
         language: system
         types: [go]
         pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
Fast pre-commit (format/lint), full tests on pre-push