### PR TITLE
ci: optimize workflows for wall clock speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,23 +19,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: Download dependencies
-        run: go mod download
-
       - name: Check go.mod tidiness
         run: |
           go mod tidy
-          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum not tidy, run 'go mod tidy'" && exit 1)
-
-      - name: Build binary for integration tests
-        run: |
-          mkdir -p bin
-          go build -o bin/smoke ./cmd/smoke
-        env:
-          CGO_ENABLED: 0
-
-      - name: Run go vet
-        run: go vet ./...
+          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum not tidy" && exit 1)
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -49,17 +36,22 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
-      - name: Run gosec
-        uses: securego/gosec@master
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          # Exclude rules that are false positives for this codebase:
-          # G104 - fnv.Write never errors
-          # G301 - config dirs (0755) are standard XDG permissions
-          # G302 - config files (0644) are standard readable permissions
-          # G304 - config paths from XDG are controlled
-          # G306 - config files don't contain secrets
-          # G404 - RNG for prompt selection, not security
-          args: -exclude=G104,G301,G302,G304,G306,G404 ./...
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build binary for integration tests
+        run: go build -o bin/smoke ./cmd/smoke
+        env:
+          CGO_ENABLED: 0
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -70,8 +62,6 @@ jobs:
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Total coverage: ${COVERAGE}%"
-          # Note: Integration tests run external binary so don't contribute to coverage
-          # Minimum: 69% (allows 1% variance), Target: 80% (SHOULD)
           if (( $(echo "$COVERAGE < 69" | bc -l) )); then
             echo "Coverage below 69% threshold"
             exit 1
@@ -82,14 +72,10 @@ jobs:
         with:
           file: ./coverage.out
           fail_ci_if_error: true
-          # Coverage delta checks configured in codecov.yml:
-          # - Project coverage MUST NOT drop below 70%
-          # - Coverage MUST NOT regress by more than 2%
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: test
     strategy:
       matrix:
         goos: [darwin, linux]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,16 @@ repos:
 
   - repo: local
     hooks:
-      - id: go-fmt
-        name: go fmt
-        entry: gofmt -l -w
+      # Use goimports to match CI (enforces import grouping)
+      - id: go-imports
+        name: goimports
+        entry: goimports -l -w
         language: system
         types: [go]
         pass_filenames: true
 
-      - id: go-vet
-        name: go vet
-        entry: bash -c 'go vet ./...'
-        language: system
-        types: [go]
-        pass_filenames: false
-
+      # golangci-lint v2 required (matches CI)
+      # Install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
       - id: golangci-lint
         name: golangci-lint
         entry: golangci-lint run
@@ -33,7 +29,7 @@ repos:
         types: [go]
         pass_filenames: false
 
-      # Tests run on pre-push, not pre-commit (see below)
+      # Tests run on pre-push, not pre-commit
       - id: go-test
         name: go test
         entry: bash -c 'go test -race ./...'


### PR DESCRIPTION
## Summary

Optimize CI workflow for faster wall clock time by running jobs in parallel.

## Changes

### CI Workflow
- **Parallel jobs**: lint, test, build now run in parallel (removed `needs: test`)
- **Removed redundant checks**: 
  - gosec (covered by golangci-lint)
  - go vet (covered by golangci-lint)
- **Removed CodeQL workflow** (not needed for this project)
- **Expected improvement**: ~3m → ~1m30s wall clock

### Local Tooling
- Pre-commit: use `goimports` instead of `gofmt` (matches CI import grouping)
- Makefile: removed redundant `vet` target
- Documented golangci-lint v2 requirement

## Test plan
- [x] Workflow syntax valid
- [ ] CI passes with new parallel structure

Generated with [Claude Code](https://claude.ai/code)