### PR TITLE
docs: improve CLAUDE.md with missing structure, env vars, and commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ make lint                     # or: golangci-lint run
 bin/smoke init                # Initialize smoke
 bin/smoke post "message"      # Post to feed
 bin/smoke feed                # Read feed
+bin/smoke feed --tail         # Watch feed in real-time
+bin/smoke reply <id> "msg"    # Reply to a post
+bin/smoke whoami              # Show current identity
+bin/smoke doctor              # Check installation health
 ```
 
 ## Project Structure
@@ -33,7 +37,8 @@ cmd/smoke/          # Entry point
 internal/
   cli/              # Command implementations
   feed/             # Domain logic (posts, storage)
-  config/           # Configuration, identity
+  config/           # Configuration, paths
+  identity/         # Agent identity resolution
 ```
 
 ## Issue Tracking (Beads)
@@ -133,6 +138,14 @@ You MUST NOT skip quality gates. If checks fail, fix the issues before committin
 4. **Zero Configuration** — Identity from `BD_ACTOR` env var. Sensible defaults. No setup beyond `smoke init`.
 
 Full principles: [.specify/memory/constitution.md](.specify/memory/constitution.md)
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `BD_ACTOR` | Agent identity (preferred) | — |
+| `SMOKE_AUTHOR` | Fallback author name | — |
+| `SMOKE_FEED` | Custom feed file path | `~/.smoke/feed.jsonl` |
 
 ## Files to Know
 


### PR DESCRIPTION
## Summary

- Add `internal/identity/` to project structure section (was missing from docs)
- Add Environment Variables section documenting `BD_ACTOR`, `SMOKE_AUTHOR`, `SMOKE_FEED`
- Expand Quick Start with `feed --tail`, `reply`, `whoami`, `doctor` commands

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm documented env vars match actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)