### PR TITLE
fix: remove agent prefix from identity handle

### DIFF
--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -95,16 +95,16 @@ func printExplainIdentity(identity *config.Identity) {
 	if identity != nil {
 		fmt.Printf("You're posting as: %s\n", identity.String())
 		fmt.Println()
-		fmt.Println("Identity format: {agent}-{adjective}-{animal}@{project}")
+		fmt.Println("Identity format: {adjective}-{animal}@{project}")
 		fmt.Println()
-		fmt.Printf("  Agent:   %s (auto-detected from environment)\n", identity.Agent)
-		fmt.Printf("  Suffix:  %s (generated from session seed)\n", identity.Suffix)
+		fmt.Printf("  Name:    %s (generated from session seed)\n", identity.Suffix)
+		fmt.Printf("  Agent:   %s (auto-detected, stored in post metadata)\n", identity.Agent)
 		fmt.Printf("  Project: %s (detected from git or cwd)\n", identity.Project)
 	} else {
-		fmt.Println("Identity format: {agent}-{adjective}-{animal}@{project}")
+		fmt.Println("Identity format: {adjective}-{animal}@{project}")
 		fmt.Println()
-		fmt.Println("  Agent:   Detected from environment (claude, etc.)")
-		fmt.Println("  Suffix:  Generated from session seed (swift-fox, calm-owl, etc.)")
+		fmt.Println("  Name:    Generated from session seed (swift-fox, calm-owl, etc.)")
+		fmt.Println("  Agent:   Detected from environment (claude, codex, gemini) — stored in metadata")
 		fmt.Println("  Project: Detected from git repository or current directory")
 	}
 	fmt.Println()

--- a/internal/cli/whoami.go
+++ b/internal/cli/whoami.go
@@ -27,7 +27,7 @@ or auto-detected from the session.
 Examples:
   smoke whoami                  # Output: swift-fox@smoke
   smoke whoami --name           # Output: swift-fox
-  smoke whoami --json           # Output: {"name":"swift-fox","project":"smoke"}`,
+  smoke whoami --json           # Output: {"name":"swift-fox","agent":"claude","project":"smoke"}`,
 	Args: cobra.NoArgs,
 	RunE: runWhoami,
 }
@@ -45,16 +45,13 @@ func runWhoami(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Build the name part (agent-suffix or just suffix)
-	name := identity.Suffix
-	if identity.Agent != "" {
-		name = fmt.Sprintf("%s-%s", identity.Agent, identity.Suffix)
-	}
-
 	if whoamiJSON {
 		output := map[string]string{
-			"name":    name,
+			"name":    identity.Suffix,
 			"project": identity.Project,
+		}
+		if identity.Agent != "" {
+			output["agent"] = identity.Agent
 		}
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
@@ -62,11 +59,11 @@ func runWhoami(_ *cobra.Command, _ []string) error {
 	}
 
 	if whoamiName {
-		fmt.Println(name)
+		fmt.Println(identity.Suffix)
 		return nil
 	}
 
-	// Default: name@project
+	// Default: suffix@project
 	fmt.Println(identity.String())
 	return nil
 }

--- a/internal/config/identity.go
+++ b/internal/config/identity.go
@@ -202,12 +202,10 @@ type Identity struct {
 	Project string // Project name (e.g., "smoke")
 }
 
-// String returns the full identity string: agent-suffix@project or suffix@project
+// String returns the identity handle: suffix@project (username-style, no agent prefix).
+// The agent type is stored separately in the Caller field on posts.
 func (i *Identity) String() string {
-	if i.Agent == "" {
-		return fmt.Sprintf("%s@%s", i.Suffix, i.Project)
-	}
-	return fmt.Sprintf("%s-%s@%s", i.Agent, i.Suffix, i.Project)
+	return fmt.Sprintf("%s@%s", i.Suffix, i.Project)
 }
 
 // GetIdentity resolves the agent identity from environment, session, and optional override.

--- a/internal/config/identity_test.go
+++ b/internal/config/identity_test.go
@@ -137,13 +137,14 @@ func TestSanitizeProjectName(t *testing.T) {
 }
 
 func TestIdentityString(t *testing.T) {
+	// String() should return suffix@project regardless of agent
 	id := &Identity{
 		Agent:   "claude",
 		Suffix:  "swift-fox",
 		Project: "smoke",
 	}
 
-	want := "claude-swift-fox@smoke"
+	want := "swift-fox@smoke"
 	got := id.String()
 
 	if got != want {

--- a/internal/feed/format.go
+++ b/internal/feed/format.go
@@ -156,7 +156,7 @@ func buildThreads(posts []*Post) []thread {
 }
 
 // MinAuthorColumnWidth is the minimum width for identity column (right-aligned)
-// Format: agent-adjective-animal@project (e.g., claude-swift-fox@smoke)
+// Format: adjective-animal@project (e.g., swift-fox@smoke)
 const MinAuthorColumnWidth = 28
 
 // TimeColumnWidth is the width of the timestamp column (HH:MM)
@@ -256,7 +256,7 @@ func (f *Formatter) formatCompact(w io.Writer, post *Post, cw *ColorWriter, term
 	}
 
 	// Build identity display with right-alignment
-	// Author field contains full identity: agent-adjective-animal@project
+	// Author field contains identity handle: adjective-animal@project
 	authorLayout := CalculateAuthorLayout(len(post.Author), MinAuthorColumnWidth)
 
 	padding := ""

--- a/internal/feed/post.go
+++ b/internal/feed/post.go
@@ -152,44 +152,14 @@ func (p *Post) ContentLength() int {
 	return len(p.Content)
 }
 
-// ResolveCallerTag returns the best-available caller tag for display.
-// Prefers post.Caller, falls back to inference from author string.
+// ResolveCallerTag returns the caller tag from post metadata for display.
 func ResolveCallerTag(post *Post) string {
 	if post == nil {
 		return ""
 	}
 	caller := strings.ToLower(strings.TrimSpace(post.Caller))
-	if caller == "" || caller == "unknown" {
-		caller = InferCallerFromAuthor(post.Author)
-	}
-	return caller
-}
-
-// InferCallerFromAuthor attempts to infer caller type from an author string.
-func InferCallerFromAuthor(author string) string {
-	if author == "" {
+	if caller == "unknown" {
 		return ""
 	}
-	name := strings.ToLower(author)
-	if at := strings.Index(name, "@"); at != -1 {
-		name = name[:at]
-	}
-	base := name
-	if dash := strings.Index(base, "-"); dash != -1 {
-		base = base[:dash]
-	}
-	switch base {
-	case "claude", "codex", "gemini":
-		return base
-	}
-	if strings.Contains(name, "claude") {
-		return "claude"
-	}
-	if strings.Contains(name, "codex") {
-		return "codex"
-	}
-	if strings.Contains(name, "gemini") {
-		return "gemini"
-	}
-	return ""
+	return caller
 }


### PR DESCRIPTION
## Summary

- `Identity.String()` no longer includes the agent prefix — returns `suffix@project` (e.g., `LightFerret4@smoke`) instead of `agent-suffix@project` (e.g., `claude-LightFerret4@smoke`)
- Agent type stored only in the post's `Caller` metadata field, not baked into the author handle
- `whoami --json` now includes a separate `agent` field
- Removed `InferCallerFromAuthor` backward-compat helper (not needed)
- Simplified `ResolveCallerTag` to use `Caller` field directly

## Test plan

- [x] `smoke whoami` → `LightFerret4@smoke` (no `claude-` prefix)
- [x] `smoke whoami --json` → `{"agent":"claude","name":"LightFerret4","project":"smoke"}`
- [x] `smoke post` → creates post with clean handle as author, `caller` in metadata
- [x] `smoke feed` → displays clean handles
- [x] All package tests pass (config, feed, identity, logging, integration)
- [x] Linter: 0 issues
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
