### PR TITLE
refactor: round 2 simplifications — hot paths, latent bugs, idioms

### DIFF
--- a/internal/cli/suggest.go
+++ b/internal/cli/suggest.go
@@ -166,7 +166,7 @@ func buildStyleModeOutput(style config.StyleMode) map[string]string {
 	}
 }
 
-func maybeAddContextOutput(output map[string]interface{}, cfg *config.SuggestConfig, contextName string) {
+func maybeAddContextOutput(output map[string]any, cfg *config.SuggestConfig, contextName string) {
 	if contextName == "" {
 		return
 	}
@@ -174,7 +174,7 @@ func maybeAddContextOutput(output map[string]interface{}, cfg *config.SuggestCon
 	if ctx == nil {
 		return
 	}
-	output["context"] = map[string]interface{}{
+	output["context"] = map[string]any{
 		"name":       contextName,
 		"prompt":     ctx.Prompt,
 		"categories": ctx.Categories,
@@ -256,7 +256,7 @@ func handleNudgeSkip(decision nudgeDecision, pressure int) error {
 	if !suggestJSON {
 		return nil
 	}
-	skipOutput := map[string]interface{}{
+	skipOutput := map[string]any{
 		"skipped":   true,
 		"pressure":  pressure,
 		"roll":      decision.roll,
@@ -497,7 +497,7 @@ func buildPostsOutput(posts []*feed.Post) []postOutput {
 }
 
 // buildReplyBaitOutput builds the reply bait section for JSON output.
-func buildReplyBaitOutput(allPosts, recentPosts []*feed.Post) map[string]interface{} {
+func buildReplyBaitOutput(allPosts, recentPosts []*feed.Post) map[string]any {
 	bait := pickReplyBait(allPosts, recentPosts)
 	if bait == nil {
 		return nil
@@ -507,7 +507,7 @@ func buildReplyBaitOutput(allPosts, recentPosts []*feed.Post) map[string]interfa
 		createdTime = time.Now()
 	}
 	prompt := replyBaitPrompts[rand.IntN(len(replyBaitPrompts))]
-	return map[string]interface{}{
+	return map[string]any{
 		"post": postOutput{
 			ID:        bait.ID,
 			Author:    bait.Author,
@@ -533,7 +533,7 @@ func formatSuggestJSONWithContext(recentPosts []*feed.Post, allPosts []*feed.Pos
 
 	style := chooseStyleMode(cfg, contextName, mode)
 
-	output := map[string]interface{}{
+	output := map[string]any{
 		"skipped":    false,
 		"pressure":   pressure,
 		"tone":       getTonePrefix(pressure),

--- a/internal/feed/color.go
+++ b/internal/feed/color.go
@@ -50,11 +50,7 @@ func Colorize(text string, codes ...string) string {
 	if len(codes) == 0 {
 		return text
 	}
-	var prefix string
-	for _, code := range codes {
-		prefix += code
-	}
-	return prefix + text + Reset
+	return strings.Join(codes, "") + text + Reset
 }
 
 // ColorWriter wraps an io.Writer and conditionally applies color.

--- a/internal/feed/format.go
+++ b/internal/feed/format.go
@@ -283,8 +283,8 @@ func (f *Formatter) formatCompact(w io.Writer, post *Post, cw *ColorWriter, term
 // Prefers breaking at a space; falls back to a hard break at width.
 func findBreakPoint(text string, width int) int {
 	breakPoint := width
-	if breakPoint > len(text) {
-		breakPoint = len(text)
+	if breakPoint >= len(text) {
+		breakPoint = len(text) - 1
 	}
 	for breakPoint > 0 && text[breakPoint] != ' ' {
 		breakPoint--

--- a/internal/feed/highlight.go
+++ b/internal/feed/highlight.go
@@ -51,9 +51,12 @@ func HighlightAll(text string, colorize bool) string {
 	if !colorize {
 		return text
 	}
-	text = HighlightHashtags(text, true)
-	text = HighlightMentions(text, true)
-	return text
+	return combinedPattern.ReplaceAllStringFunc(text, func(match string) string {
+		if match[0] == '#' {
+			return Colorize(match, Dim, FgCyan)
+		}
+		return Colorize(match, Dim, FgMagenta)
+	})
 }
 
 // HighlightWithTheme applies highlighting with proper background color from theme.

--- a/internal/feed/locale.go
+++ b/internal/feed/locale.go
@@ -69,9 +69,11 @@ func parseLocaleTimeFormat(locale string) TimeFormat {
 	return TimeFormat24h
 }
 
+var detectedFormat = DetectTimeFormat()
+
 // FormatTime formats a time value according to the detected locale preference.
 func FormatTime(t time.Time) string {
-	return FormatTimeWithFormat(t, DetectTimeFormat())
+	return FormatTimeWithFormat(t, detectedFormat)
 }
 
 // FormatTimeWithFormat formats a time value with the specified format preference.

--- a/internal/feed/post.go
+++ b/internal/feed/post.go
@@ -2,6 +2,7 @@ package feed
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -42,7 +43,7 @@ type Post struct {
 var ErrEmptyContent = errors.New("content cannot be empty")
 
 // ErrContentTooLong is returned when a post's content exceeds MaxContentLength.
-var ErrContentTooLong = errors.New("message exceeds 280 characters")
+var ErrContentTooLong = fmt.Errorf("message exceeds %d characters", MaxContentLength)
 
 // ErrEmptyAuthor is returned when a post's author is empty.
 var ErrEmptyAuthor = errors.New("author cannot be empty")

--- a/internal/feed/tui.go
+++ b/internal/feed/tui.go
@@ -1507,7 +1507,8 @@ func (m Model) buildRightHelpColumn(hs helpStyles) string {
 func (m Model) renderHelpOverlayBox() overlayBox {
 	hs := m.newHelpStyles()
 
-	leftBlock := m.fillBackgroundBlock(buildLeftHelpColumn(hs), blockWidth(buildLeftHelpColumn(hs)), m.theme.BackgroundSecondary)
+	leftCol := buildLeftHelpColumn(hs)
+	leftBlock := m.fillBackgroundBlock(leftCol, blockWidth(leftCol), m.theme.BackgroundSecondary)
 	rightBlock := m.buildRightHelpColumn(hs)
 	rightBlock = m.fillBackgroundBlock(rightBlock, blockWidth(rightBlock), m.theme.BackgroundSecondary)
 
@@ -1842,7 +1843,7 @@ func (cb *contentBuilder) addThread(thread thread, postIndex int) {
 		cb.lines = append(cb.lines, contentLine{text: line, postIndex: postIndex})
 	}
 	for _, reply := range thread.replies {
-		for _, line := range cb.model.formatReplyWithSelection(reply, false) {
+		for _, line := range cb.model.formatReply(reply) {
 			cb.lines = append(cb.lines, contentLine{text: line, postIndex: -1})
 		}
 	}
@@ -1900,12 +1901,6 @@ func (m Model) formatPostWithSelection(post *Post, isSelected bool) []string {
 		lines[i] = m.padLineToWidth(line, m.selectionBackground())
 	}
 	return lines
-}
-
-// formatReplyWithSelection formats a reply with optional selection indicator.
-func (m Model) formatReplyWithSelection(reply *Post, isSelected bool) []string {
-	// Replies are not selectable in the current UI.
-	return m.formatReply(reply)
 }
 
 // handleCopyMenuKey handles key events when the copy menu is visible.


### PR DESCRIPTION
## Summary

Second simplification pass across `internal/feed/` and `internal/cli/`. 7 files changed, +23/-26 lines.

### Correctness
- Fix `findBreakPoint` off-by-one panic when `width >= len(text)`
- Use `MaxContentLength` in `ErrContentTooLong` message (was hardcoded)

### Performance
- Cache `DetectTimeFormat` result at package level (was reading env vars every second in tail mode)
- Optimize `HighlightAll` to single regex scan via `combinedPattern`
- Eliminate duplicate `buildLeftHelpColumn` call in help rendering

### Cleanup
- Remove dead `formatReplyWithSelection` wrapper and unused `isSelected` param
- Use `strings.Join` for ANSI code concatenation in `Colorize`
- Replace `map[string]interface{}` with `map[string]any` in `suggest.go`

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] Pre-commit hooks pass
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)