### PR TITLE
refactor: round 3 — dead code, idioms across logging, hooks, config

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -650,7 +650,7 @@ func performTUIConfigCheck() Check {
 	}
 
 	// Parse as generic map to check for deprecated fields
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err := yaml.Unmarshal(data, &parsed); err != nil {
 		return Check{Name: name, Status: StatusFail, Message: "invalid YAML", Detail: err.Error()}
 	}
@@ -713,7 +713,7 @@ func fixTUIConfigStyleToLayout(tuiPath string) (*FixResult, error) {
 	}
 
 	// Parse as generic map
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err = yaml.Unmarshal(data, &parsed); err != nil {
 		return nil, err
 	}

--- a/internal/config/identity.go
+++ b/internal/config/identity.go
@@ -290,52 +290,6 @@ func autoDetectIdentity(project string) (*Identity, error) {
 	}, nil
 }
 
-// parseFullIdentity parses "agent-suffix@project" or "name@project" format
-// NOTE: @project is ALWAYS auto-detected and cannot be overridden
-func parseFullIdentity(s string) (*Identity, error) {
-	parts := strings.SplitN(s, "@", 2)
-
-	// Extract name part (before @, or whole string if no @)
-	agentSuffix := parts[0]
-
-	// ALWAYS auto-detect project, ignore @ override
-	project := detectProject()
-
-	// Split agent-suffix (e.g., "claude-swift-fox" -> "claude", "swift-fox")
-	firstDash := strings.Index(agentSuffix, "-")
-	if firstDash == -1 {
-		// Simple name without dash (e.g., "ember@testrig")
-		// Use as suffix only, no agent prefix
-		return &Identity{
-			Agent:   "",
-			Suffix:  sanitizeName(agentSuffix),
-			Project: project,
-		}, nil
-	}
-
-	return &Identity{
-		Agent:   sanitizeName(agentSuffix[:firstDash]),
-		Suffix:  sanitizeName(agentSuffix[firstDash+1:]),
-		Project: project,
-	}, nil
-}
-
-// detectAgent determines the agent type from environment
-func detectAgent() string {
-	// Check for Claude Code
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "unknown"
-	}
-
-	claudeDir := filepath.Join(home, ".claude")
-	if _, err := os.Stat(claudeDir); err == nil {
-		return "claude"
-	}
-
-	return "unknown"
-}
-
 // getSessionSeed returns a stable seed for the current session.
 // Walks the process tree to find an agent ancestor (Claude, Codex, Gemini),
 // ensuring all commands within the same session get the same identity regardless

--- a/internal/config/identity_test.go
+++ b/internal/config/identity_test.go
@@ -52,38 +52,6 @@ func TestGetIdentityWithOverride(t *testing.T) {
 	}
 }
 
-func TestParseFullIdentity(t *testing.T) {
-	// Get the actual auto-detected project for comparison
-	actualProject := detectProject()
-
-	tests := []struct {
-		input  string
-		agent  string
-		suffix string
-	}{
-		{"claude-swift-fox@smoke", "claude", "swift-fox"},
-		{"unknown-calm-owl@myproject", "unknown", "calm-owl"},
-		{"custom@test", "", "custom"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			id, err := parseFullIdentity(tt.input)
-			require.NoError(t, err)
-			if id.Agent != tt.agent {
-				t.Errorf("Agent: got %q, want %q", id.Agent, tt.agent)
-			}
-			if id.Suffix != tt.suffix {
-				t.Errorf("Suffix: got %q, want %q", id.Suffix, tt.suffix)
-			}
-			// Project should ALWAYS be auto-detected, not from input
-			if id.Project != actualProject {
-				t.Errorf("Project: got %q, want auto-detected %q (input @project should be ignored)", id.Project, actualProject)
-			}
-		})
-	}
-}
-
 func TestDetectProject(t *testing.T) {
 	project := detectProject()
 	if project == "" {
@@ -217,70 +185,6 @@ func TestGetIdentity_FallsBackToSessionSeed(t *testing.T) {
 		t.Errorf("Expected agent %q, got %q", detectedAgent, identity.Agent)
 	}
 	t.Logf("Identity with PPID fallback: %s", identity.String())
-}
-
-func TestParseFullIdentity_AllComponents(t *testing.T) {
-	// Get the actual auto-detected project
-	actualProject := detectProject()
-
-	tests := []struct {
-		name   string
-		input  string
-		wantID *Identity
-	}{
-		{
-			name:  "valid format with @project (project ignored)",
-			input: "agent-suffix@ignored-project",
-			wantID: &Identity{
-				Agent:   "agent",
-				Suffix:  "suffix",
-				Project: actualProject, // ALWAYS auto-detected
-			},
-		},
-		{
-			name:  "no agent dash with @project (project ignored)",
-			input: "agent@ignored-project",
-			wantID: &Identity{
-				Agent:   "",
-				Suffix:  "agent",
-				Project: actualProject, // ALWAYS auto-detected
-			},
-		},
-		{
-			name:  "no project separator (project auto-detected)",
-			input: "agent-suffix",
-			wantID: &Identity{
-				Agent:   "agent",
-				Suffix:  "suffix",
-				Project: actualProject, // ALWAYS auto-detected
-			},
-		},
-		{
-			name:  "case insensitive with @project (project ignored)",
-			input: "Agent-Suffix@Ignored-Project",
-			wantID: &Identity{
-				Agent:   "agent",
-				Suffix:  "suffix",
-				Project: actualProject, // ALWAYS auto-detected
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			id, err := parseFullIdentity(tt.input)
-			require.NoError(t, err)
-			if id.Agent != tt.wantID.Agent {
-				t.Errorf("Agent: got %q, want %q", id.Agent, tt.wantID.Agent)
-			}
-			if id.Suffix != tt.wantID.Suffix {
-				t.Errorf("Suffix: got %q, want %q", id.Suffix, tt.wantID.Suffix)
-			}
-			if id.Project != tt.wantID.Project {
-				t.Errorf("Project: got %q, want %q (should be auto-detected)", id.Project, tt.wantID.Project)
-			}
-		})
-	}
 }
 
 func TestDetectProject_InGitRepo(t *testing.T) {
@@ -551,17 +455,6 @@ func TestGetIdentity_NoSessionSeed(t *testing.T) {
 		// If no error, PPID fallback worked
 		t.Logf("Identity resolved via PPID fallback: %s", identity.String())
 	}
-}
-
-func TestDetectAgent_NoClaudeDir(t *testing.T) {
-	// Manually test detectAgent behavior
-	// The function checks for ~/.claude directory
-	agent := detectAgent()
-	// The function should return either "claude" or "unknown"
-	if agent != "claude" && agent != "unknown" {
-		t.Errorf("detectAgent() returned unexpected value: %q", agent)
-	}
-	t.Logf("detectAgent returned: %q", agent)
 }
 
 func TestExtractRepoName_SSHWithColonNoSlash(t *testing.T) {

--- a/internal/feed/highlight.go
+++ b/internal/feed/highlight.go
@@ -17,36 +17,9 @@ var (
 	combinedPattern = regexp.MustCompile(`(#[a-zA-Z0-9_]+|@[a-zA-Z0-9_]+)`)
 )
 
-// HighlightHashtags colorizes hashtags in dim cyan (muted).
+// HighlightAll applies ANSI highlighting (hashtags and mentions) to text.
 // If colorize is false, returns text unchanged.
-//
-// Deprecated: Use HighlightWithTheme instead to include background color.
-func HighlightHashtags(text string, colorize bool) string {
-	if !colorize {
-		return text
-	}
-	return HashtagPattern.ReplaceAllStringFunc(text, func(match string) string {
-		return Colorize(match, Dim, FgCyan)
-	})
-}
-
-// HighlightMentions colorizes mentions in dim magenta (muted).
-// If colorize is false, returns text unchanged.
-//
-// Deprecated: Use HighlightWithTheme instead to include background color.
-func HighlightMentions(text string, colorize bool) string {
-	if !colorize {
-		return text
-	}
-	return MentionPattern.ReplaceAllStringFunc(text, func(match string) string {
-		return Colorize(match, Dim, FgMagenta)
-	})
-}
-
-// HighlightAll applies all highlighting (hashtags and mentions) to text.
-// If colorize is false, returns text unchanged.
-//
-// Deprecated: Use HighlightWithTheme instead to include background color.
+// For TUI rendering with background colors, use HighlightWithTheme instead.
 func HighlightAll(text string, colorize bool) string {
 	if !colorize {
 		return text

--- a/internal/feed/highlight_test.go
+++ b/internal/feed/highlight_test.go
@@ -69,58 +69,6 @@ func TestMentionPattern(t *testing.T) {
 	}
 }
 
-func TestHighlightHashtags(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		colorize bool
-		wantCyan bool
-	}{
-		{"with color", "hello #world", true, true},
-		{"without color", "hello #world", false, false},
-		{"no hashtag", "hello world", true, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := HighlightHashtags(tt.input, tt.colorize)
-			hasCyan := strings.Contains(result, FgCyan)
-			if hasCyan != tt.wantCyan {
-				t.Errorf("cyan color present = %v, want %v", hasCyan, tt.wantCyan)
-			}
-			if tt.wantCyan && !strings.Contains(result, Reset) {
-				t.Error("expected Reset code when color applied")
-			}
-		})
-	}
-}
-
-func TestHighlightMentions(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       string
-		colorize    bool
-		wantMagenta bool
-	}{
-		{"with color", "hello @user", true, true},
-		{"without color", "hello @user", false, false},
-		{"no mention", "hello world", true, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := HighlightMentions(tt.input, tt.colorize)
-			hasMagenta := strings.Contains(result, FgMagenta)
-			if hasMagenta != tt.wantMagenta {
-				t.Errorf("magenta color present = %v, want %v", hasMagenta, tt.wantMagenta)
-			}
-			if tt.wantMagenta && !strings.Contains(result, Reset) {
-				t.Error("expected Reset code when color applied")
-			}
-		})
-	}
-}
-
 func TestHighlightAll(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -53,7 +54,7 @@ func installScriptFiles(hooksDir string) error {
 func loadOrResetSettings(result *InstallResult) (map[string]interface{}, error) {
 	settings, err := readSettings()
 	if err != nil {
-		if err == ErrInvalidSettings {
+		if errors.Is(err, ErrInvalidSettings) {
 			backupPath, backupErr := BackupSettings()
 			if backupErr != nil {
 				return nil, fmt.Errorf("backup invalid settings: %w", backupErr)
@@ -123,7 +124,7 @@ type UninstallResult struct {
 // If settings are invalid, it skips settings modification silently.
 func removeSettingsHooks(result *UninstallResult) error {
 	settings, err := readSettings()
-	if err != nil && err != ErrInvalidSettings {
+	if err != nil && !errors.Is(err, ErrInvalidSettings) {
 		return err
 	}
 	if err != nil {

--- a/internal/hooks/settings.go
+++ b/internal/hooks/settings.go
@@ -11,12 +11,12 @@ import (
 
 // readSettings reads and parses Claude Code settings.json
 // Returns empty map if file doesn't exist
-func readSettings() (map[string]interface{}, error) {
+func readSettings() (map[string]any, error) {
 	settingsPath := GetSettingsPath()
 
 	// If file doesn't exist, return empty settings
 	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
-		return make(map[string]interface{}), nil
+		return make(map[string]any), nil
 	}
 
 	// Read file
@@ -26,7 +26,7 @@ func readSettings() (map[string]interface{}, error) {
 	}
 
 	// Parse JSON
-	var settings map[string]interface{}
+	var settings map[string]any
 	if err := json.Unmarshal(data, &settings); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidSettings, err)
 	}
@@ -35,7 +35,7 @@ func readSettings() (map[string]interface{}, error) {
 }
 
 // writeSettings writes settings atomically to settings.json
-func writeSettings(settings map[string]interface{}) error {
+func writeSettings(settings map[string]any) error {
 	settingsPath := GetSettingsPath()
 
 	// Ensure parent directory exists
@@ -105,9 +105,9 @@ func isSmokeHook(command string) bool {
 
 // updateSmokeHookCommand searches a hooks array for a smoke hook and updates its command.
 // Returns true if a smoke hook was found and updated.
-func updateSmokeHookCommand(hooks []interface{}, scriptPath string) bool {
+func updateSmokeHookCommand(hooks []any, scriptPath string) bool {
 	for _, hook := range hooks {
-		hookMap, ok := hook.(map[string]interface{})
+		hookMap, ok := hook.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -122,13 +122,13 @@ func updateSmokeHookCommand(hooks []interface{}, scriptPath string) bool {
 
 // findSmokeHookInEntries searches event entries for a smoke hook and updates its command.
 // Returns true if a smoke hook was found and updated.
-func findSmokeHookInEntries(eventArray []interface{}, scriptPath string) bool {
+func findSmokeHookInEntries(eventArray []any, scriptPath string) bool {
 	for _, entry := range eventArray {
-		entryMap, ok := entry.(map[string]interface{})
+		entryMap, ok := entry.(map[string]any)
 		if !ok {
 			continue
 		}
-		entryHooks, ok := entryMap["hooks"].([]interface{})
+		entryHooks, ok := entryMap["hooks"].([]any)
 		if !ok {
 			continue
 		}
@@ -140,27 +140,27 @@ func findSmokeHookInEntries(eventArray []interface{}, scriptPath string) bool {
 }
 
 // addHookToSettings adds or updates a smoke hook in settings
-func addHookToSettings(settings map[string]interface{}, event HookEvent, scriptPath string) error {
+func addHookToSettings(settings map[string]any, event HookEvent, scriptPath string) error {
 	// Ensure hooks section exists
-	hooks, ok := settings["hooks"].(map[string]interface{})
+	hooks, ok := settings["hooks"].(map[string]any)
 	if !ok {
-		hooks = make(map[string]interface{})
+		hooks = make(map[string]any)
 		settings["hooks"] = hooks
 	}
 
 	// Get or create event array
 	eventKey := string(event)
-	eventArray, ok := hooks[eventKey].([]interface{})
+	eventArray, ok := hooks[eventKey].([]any)
 	if !ok {
-		eventArray = []interface{}{}
+		eventArray = []any{}
 	}
 
 	// Update existing smoke hook or add new entry
 	if !findSmokeHookInEntries(eventArray, scriptPath) {
-		newEntry := map[string]interface{}{
+		newEntry := map[string]any{
 			"matcher": "",
-			"hooks": []interface{}{
-				map[string]interface{}{
+			"hooks": []any{
+				map[string]any{
 					"type":    "command",
 					"command": scriptPath,
 				},
@@ -175,21 +175,21 @@ func addHookToSettings(settings map[string]interface{}, event HookEvent, scriptP
 
 // filterSmokeHooksFromEntry removes smoke hooks from a single entry.
 // Returns the filtered entry and whether it should be kept.
-func filterSmokeHooksFromEntry(entry interface{}) (interface{}, bool) {
-	entryMap, ok := entry.(map[string]interface{})
+func filterSmokeHooksFromEntry(entry any) (any, bool) {
+	entryMap, ok := entry.(map[string]any)
 	if !ok {
 		return entry, true
 	}
 
-	entryHooks, ok := entryMap["hooks"].([]interface{})
+	entryHooks, ok := entryMap["hooks"].([]any)
 	if !ok {
 		return entry, true
 	}
 
 	// Filter hooks within entry
-	var filteredHooks []interface{}
+	var filteredHooks []any
 	for _, hook := range entryHooks {
-		hookMap, ok := hook.(map[string]interface{})
+		hookMap, ok := hook.(map[string]any)
 		if !ok {
 			filteredHooks = append(filteredHooks, hook)
 			continue
@@ -210,22 +210,22 @@ func filterSmokeHooksFromEntry(entry interface{}) (interface{}, bool) {
 }
 
 // removeHookFromSettings removes smoke hooks from settings
-func removeHookFromSettings(settings map[string]interface{}, event HookEvent) error {
+func removeHookFromSettings(settings map[string]any, event HookEvent) error {
 	// Get hooks section
-	hooks, ok := settings["hooks"].(map[string]interface{})
+	hooks, ok := settings["hooks"].(map[string]any)
 	if !ok {
 		return nil // No hooks section, nothing to remove
 	}
 
 	// Get event array
 	eventKey := string(event)
-	eventArray, ok := hooks[eventKey].([]interface{})
+	eventArray, ok := hooks[eventKey].([]any)
 	if !ok {
 		return nil // No entries for this event
 	}
 
 	// Filter out entries with only smoke hooks
-	var filtered []interface{}
+	var filtered []any
 	for _, entry := range eventArray {
 		if kept, keep := filterSmokeHooksFromEntry(entry); keep {
 			filtered = append(filtered, kept)
@@ -243,9 +243,9 @@ func removeHookFromSettings(settings map[string]interface{}, event HookEvent) er
 }
 
 // hooksContainSmoke checks if any hook in the array is a smoke hook.
-func hooksContainSmoke(hooks []interface{}) bool {
+func hooksContainSmoke(hooks []any) bool {
 	for _, hook := range hooks {
-		hookMap, ok := hook.(map[string]interface{})
+		hookMap, ok := hook.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -257,13 +257,13 @@ func hooksContainSmoke(hooks []interface{}) bool {
 }
 
 // entriesContainSmokeHook checks if any entry in the event array contains a smoke hook.
-func entriesContainSmokeHook(eventArray []interface{}) bool {
+func entriesContainSmokeHook(eventArray []any) bool {
 	for _, entry := range eventArray {
-		entryMap, ok := entry.(map[string]interface{})
+		entryMap, ok := entry.(map[string]any)
 		if !ok {
 			continue
 		}
-		entryHooks, ok := entryMap["hooks"].([]interface{})
+		entryHooks, ok := entryMap["hooks"].([]any)
 		if !ok {
 			continue
 		}
@@ -275,14 +275,14 @@ func entriesContainSmokeHook(eventArray []interface{}) bool {
 }
 
 // checkHookInSettings checks if a smoke hook is configured in settings
-func checkHookInSettings(settings map[string]interface{}, event HookEvent) bool {
-	hooks, ok := settings["hooks"].(map[string]interface{})
+func checkHookInSettings(settings map[string]any, event HookEvent) bool {
+	hooks, ok := settings["hooks"].(map[string]any)
 	if !ok {
 		return false
 	}
 
 	eventKey := string(event)
-	eventArray, ok := hooks[eventKey].([]interface{})
+	eventArray, ok := hooks[eventKey].([]any)
 	if !ok {
 		return false
 	}

--- a/internal/logging/commands.go
+++ b/internal/logging/commands.go
@@ -60,18 +60,3 @@ func LogWarn(msg string, args ...any) {
 	Logger().Warn(msg, args...)
 	Verbose(msg, args...)
 }
-
-// LogCommand is deprecated. Use StartCommand() instead.
-// Kept for backward compatibility during migration.
-func LogCommand(cmd string, args []string) {
-	Logger().Info("command invoked",
-		slog.Group("cmd",
-			slog.String("name", cmd),
-			slog.Any("args", args),
-		),
-	)
-	Verbose("command invoked",
-		slog.String("cmd.name", cmd),
-		slog.Any("cmd.args", args),
-	)
-}

--- a/internal/logging/commands_test.go
+++ b/internal/logging/commands_test.go
@@ -9,37 +9,6 @@ import (
 	"testing"
 )
 
-func TestLogCommand(t *testing.T) {
-	resetGlobalState()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.log")
-
-	cfg := Config{
-		Level:    slog.LevelInfo,
-		Path:     path,
-		MaxSize:  DefaultMaxSize,
-		MaxFiles: DefaultMaxFiles,
-	}
-	Init(cfg)
-	defer Close()
-
-	// Log a command
-	LogCommand("post", []string{"hello", "world"})
-
-	// Verify log file contains the command
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if !strings.Contains(string(data), "command invoked") {
-		t.Errorf("log should contain 'command invoked', got: %s", string(data))
-	}
-	if !strings.Contains(string(data), "post") {
-		t.Errorf("log should contain 'post', got: %s", string(data))
-	}
-}
-
 func TestLogPostCreated(t *testing.T) {
 	resetGlobalState()
 

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -264,12 +263,4 @@ func itoa(i int) string {
 		b.WriteByte(digits[n])
 	}
 	return b.String()
-}
-
-// extractProjectFromCwd attempts to extract project name from cwd.
-func extractProjectFromCwd(cwd string) string {
-	if cwd == "" {
-		return ""
-	}
-	return filepath.Base(cwd)
 }

--- a/internal/logging/context_test.go
+++ b/internal/logging/context_test.go
@@ -333,22 +333,3 @@ func TestItoa(t *testing.T) {
 		}
 	}
 }
-
-func TestExtractProjectFromCwd(t *testing.T) {
-	tests := []struct {
-		cwd      string
-		expected string
-	}{
-		{"/home/user/projects/smoke", "smoke"},
-		{"/home/user/smoke", "smoke"},
-		{"", ""},
-		{"/", "/"},
-	}
-
-	for _, tt := range tests {
-		result := extractProjectFromCwd(tt.cwd)
-		if result != tt.expected {
-			t.Errorf("extractProjectFromCwd(%q) = %q, want %q", tt.cwd, result, tt.expected)
-		}
-	}
-}

--- a/internal/logging/tracker.go
+++ b/internal/logging/tracker.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -146,53 +147,25 @@ func categorizeError(err error) string {
 		return "none"
 	}
 
-	msg := err.Error()
+	lowered := strings.ToLower(err.Error())
 
 	// Check for common error patterns
 	switch {
-	case contains(msg, "not initialized"):
+	case strings.Contains(lowered, "not initialized"):
 		return "not_initialized"
-	case contains(msg, "permission"):
+	case strings.Contains(lowered, "permission"):
 		return "permission"
-	case contains(msg, "not found"):
+	case strings.Contains(lowered, "not found"):
 		return "not_found"
-	case contains(msg, "timeout"):
+	case strings.Contains(lowered, "timeout"):
 		return "timeout"
-	case contains(msg, "invalid"):
+	case strings.Contains(lowered, "invalid"):
 		return "invalid_input"
-	case contains(msg, "parse"):
+	case strings.Contains(lowered, "parse"):
 		return "parse_error"
-	case contains(msg, "connection"):
+	case strings.Contains(lowered, "connection"):
 		return "connection"
 	default:
 		return "unknown"
 	}
-}
-
-// contains checks if s contains substr (case-insensitive).
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && containsLower(toLower(s), toLower(substr))
-}
-
-// toLower converts ASCII characters to lowercase.
-func toLower(s string) string {
-	b := make([]byte, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		b[i] = c
-	}
-	return string(b)
-}
-
-// containsLower checks if s contains substr (both assumed lowercase).
-func containsLower(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/logging/tracker_test.go
+++ b/internal/logging/tracker_test.go
@@ -145,47 +145,6 @@ func TestCategorizeError(t *testing.T) {
 	}
 }
 
-func TestContains(t *testing.T) {
-	tests := []struct {
-		s        string
-		substr   string
-		expected bool
-	}{
-		{"hello world", "world", true},
-		{"Hello World", "world", true}, // case insensitive
-		{"hello", "world", false},
-		{"", "test", false},
-		{"test", "", true},
-	}
-
-	for _, tt := range tests {
-		result := contains(tt.s, tt.substr)
-		if result != tt.expected {
-			t.Errorf("contains(%q, %q) = %v, want %v", tt.s, tt.substr, result, tt.expected)
-		}
-	}
-}
-
-func TestToLower(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"HELLO", "hello"},
-		{"Hello", "hello"},
-		{"hello", "hello"},
-		{"Hello123", "hello123"},
-		{"", ""},
-	}
-
-	for _, tt := range tests {
-		result := toLower(tt.input)
-		if result != tt.expected {
-			t.Errorf("toLower(%q) = %q, want %q", tt.input, result, tt.expected)
-		}
-	}
-}
-
 // TestTrackerIntegration tests the full tracking flow with a captured log
 func TestTrackerIntegration(t *testing.T) {
 	// Create a buffer to capture log output


### PR DESCRIPTION
## Summary

Third simplification pass — focused on logging, hooks, config, and highlight packages. 13 files changed, +50/-423 lines (net -373).

### Dead code removal
- Remove `extractProjectFromCwd`, `parseFullIdentity`, `detectAgent` from config/identity.go
- Remove `LogCommand` from logging/commands.go
- Remove `HighlightHashtags`, `HighlightMentions` from feed/highlight.go (callers eliminated in round 2)
- Remove associated tests for all deleted functions

### Correctness
- Use `errors.Is` for `ErrInvalidSettings` comparison in hooks.go

### Idioms
- Replace hand-rolled case-insensitive contains with `strings.ToLower` + `strings.Contains` in tracker.go
- Replace all remaining `interface{}` with `any` in hooks/settings.go and cli/doctor.go (Go 1.18+)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] Pre-commit hooks pass
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)