### PR TITLE
refactor: round 4 — remove dead exports, replace hand-rolled helpers

### DIFF
--- a/internal/cli/suggest.go
+++ b/internal/cli/suggest.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand/v2" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"os"
@@ -564,7 +565,7 @@ func formatSuggestJSONWithContext(recentPosts []*feed.Post, allPosts []*feed.Pos
 // formatSuggestPost formats a single post for the suggest output
 // Format: "smk-XXXXXX | author@project (Xm ago)"
 // Followed by the post content on the next line
-func formatSuggestPost(w *os.File, post *feed.Post, full bool) {
+func formatSuggestPost(w io.Writer, post *feed.Post, full bool) {
 	createdTime, err := post.GetCreatedTime()
 	if err != nil {
 		// Fallback if time parsing fails

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -67,22 +67,3 @@ type SettingsInfo struct {
 type InstallOptions struct {
 	Force bool // Overwrite modified scripts
 }
-
-// SettingsHooks represents the hooks section of Claude Code settings.json
-type SettingsHooks struct {
-	Stop        []SettingsHookEntry `json:"Stop,omitempty"`
-	PostToolUse []SettingsHookEntry `json:"PostToolUse,omitempty"`
-	// Other events are preserved but not modified by smoke
-}
-
-// SettingsHookEntry represents a hook configuration entry
-type SettingsHookEntry struct {
-	Matcher string       `json:"matcher"`
-	Hooks   []HookConfig `json:"hooks"`
-}
-
-// HookConfig represents an individual hook within an entry
-type HookConfig struct {
-	Type    string `json:"type"`    // Always "command" for shell scripts
-	Command string `json:"command"` // Full path to script
-}

--- a/internal/identity/generator.go
+++ b/internal/identity/generator.go
@@ -48,12 +48,6 @@ func Generate(seed string) string {
 	return fmt.Sprintf("%s-%s", Adjectives[adjIdx], Animals[animalIdx])
 }
 
-// GenerateFull creates a full identity string in the format: agent-adjective-animal@project
-func GenerateFull(agent, seed, project string) string {
-	suffix := Generate(seed)
-	return fmt.Sprintf("%s-%s@%s", agent, suffix, project)
-}
-
 // SelectPattern selects a naming pattern based on a seed hash.
 // Different seeds should produce different (though not necessarily unique) pattern selections.
 func SelectPattern(seed string) Pattern {

--- a/internal/identity/generator_test.go
+++ b/internal/identity/generator_test.go
@@ -53,33 +53,6 @@ func TestGenerate_Format(t *testing.T) {
 	}
 }
 
-func TestGenerateFull(t *testing.T) {
-	tests := []struct {
-		agent   string
-		seed    string
-		project string
-		wantFmt string // regex-like pattern
-	}{
-		{"claude", "session-1", "smoke", "claude-"},
-		{"unknown", "session-2", "myproject", "unknown-"},
-	}
-
-	for _, tt := range tests {
-		result := GenerateFull(tt.agent, tt.seed, tt.project)
-
-		// Should start with agent-
-		if len(result) < len(tt.agent)+1 {
-			t.Errorf("GenerateFull too short: %q", result)
-		}
-
-		// Should contain @project
-		wantSuffix := "@" + tt.project
-		if result[len(result)-len(wantSuffix):] != wantSuffix {
-			t.Errorf("GenerateFull missing project suffix: got %q, want suffix %q", result, wantSuffix)
-		}
-	}
-}
-
 // TestGenerateWithPattern tests the new multi-pattern generation functionality.
 // This test suite validates pattern selection and pattern-specific generation.
 func TestGenerateWithPattern(t *testing.T) {
@@ -416,31 +389,6 @@ func TestSessionSeedConsistency(t *testing.T) {
 	}
 
 	t.Logf("Session seed %q consistently produced username: %q", sessionSeed, username1)
-}
-
-// TestGenerateFullDeterminism verifies that GenerateFull() returns identical results across multiple calls.
-// This validates determinism of the complete identity generation including agent and project fields.
-func TestGenerateFullDeterminism(t *testing.T) {
-	agent := "test-agent"
-	seed := "full-determinism-seed"
-	project := "test-project"
-	numCalls := 12
-
-	// Call GenerateFull multiple times with the same parameters
-	results := make([]string, numCalls)
-	for i := 0; i < numCalls; i++ {
-		results[i] = GenerateFull(agent, seed, project)
-	}
-
-	// All results must be identical
-	expected := results[0]
-	for i := 1; i < numCalls; i++ {
-		if results[i] != expected {
-			t.Errorf("GenerateFull determinism failed at call %d: got %q, expected %q", i+1, results[i], expected)
-		}
-	}
-
-	t.Logf("GenerateFull returned consistent result across %d calls: %q", numCalls, expected)
 }
 
 // TestVerbNounPattern specifically validates VerbNoun generation logic.

--- a/internal/identity/words.go
+++ b/internal/identity/words.go
@@ -65,13 +65,3 @@ var TechTerms = [30]string{
 	"mutex", "neural", "node", "parse", "pivot",
 	"query", "queue", "regex", "schema", "socket",
 }
-
-// Colors for identity generation (25 words)
-// Criteria: vivid, easy to spell, palette diversity
-var Colors = [25]string{
-	"amber", "azure", "bronze", "cerise", "coral",
-	"cyan", "ebony", "ember", "fawn", "gold",
-	"indigo", "ivory", "jade", "lemon", "lilac",
-	"magenta", "olive", "peach", "plum", "ruby",
-	"sage", "sienna", "slate", "tan", "ultra",
-}

--- a/internal/logging/commands.go
+++ b/internal/logging/commands.go
@@ -4,35 +4,6 @@ import (
 	"log/slog"
 )
 
-// LogPostCreated logs a post creation event.
-// Use within a tracked command to correlate with command context.
-func LogPostCreated(id, author string) {
-	Logger().Info("post created",
-		slog.Group("post",
-			slog.String("id", id),
-			slog.String("author", author),
-		),
-	)
-	Verbose("post created",
-		slog.String("post.id", id),
-		slog.String("post.author", author),
-	)
-}
-
-// LogFeedRead logs a feed read operation with metrics.
-func LogFeedRead(sizeBytes int64, postCount int) {
-	Logger().Info("feed read",
-		slog.Group("feed",
-			slog.Int64("size_bytes", sizeBytes),
-			slog.Int("post_count", postCount),
-		),
-	)
-	Verbose("feed read",
-		slog.Int64("feed.size_bytes", sizeBytes),
-		slog.Int("feed.post_count", postCount),
-	)
-}
-
 // LogError logs an error with categorization.
 // Prefer using CommandTracker.Fail() for command-level errors.
 func LogError(msg string, err error) {

--- a/internal/logging/commands_test.go
+++ b/internal/logging/commands_test.go
@@ -9,37 +9,6 @@ import (
 	"testing"
 )
 
-func TestLogPostCreated(t *testing.T) {
-	resetGlobalState()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.log")
-
-	cfg := Config{
-		Level:    slog.LevelInfo,
-		Path:     path,
-		MaxSize:  DefaultMaxSize,
-		MaxFiles: DefaultMaxFiles,
-	}
-	Init(cfg)
-	defer Close()
-
-	// Log a post creation
-	LogPostCreated("smk-abc123", "test-author")
-
-	// Verify log file contains the post info
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if !strings.Contains(string(data), "post created") {
-		t.Errorf("log should contain 'post created', got: %s", string(data))
-	}
-	if !strings.Contains(string(data), "smk-abc123") {
-		t.Errorf("log should contain 'smk-abc123', got: %s", string(data))
-	}
-}
-
 func TestLogError(t *testing.T) {
 	resetGlobalState()
 

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -141,11 +141,6 @@ func detectCallerAgentFromEnv() string {
 	return ""
 }
 
-// DetectCallerAgent returns the detected caller agent type.
-func DetectCallerAgent() string {
-	return detectCallerAgent()
-}
-
 // findAgentAncestor walks up the process tree looking for a process name match.
 func findAgentAncestor(substr string) bool {
 	substr = strings.ToLower(substr)
@@ -239,28 +234,5 @@ func getSessionID() string {
 
 // formatSessionID creates a consistent session ID format.
 func formatSessionID(prefix string, pid int) string {
-	return prefix + "-" + itoa(pid)
-}
-
-// itoa converts int to string without fmt dependency.
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	if i < 0 {
-		return "-" + itoa(-i)
-	}
-	var b strings.Builder
-	var digits [20]byte
-	n := 0
-	for i > 0 {
-		digits[n] = byte('0' + i%10)
-		i /= 10
-		n++
-	}
-	for n > 0 {
-		n--
-		b.WriteByte(digits[n])
-	}
-	return b.String()
+	return prefix + "-" + strconv.Itoa(pid)
 }

--- a/internal/logging/context_test.go
+++ b/internal/logging/context_test.go
@@ -312,24 +312,3 @@ func TestDetectCallerAgentFromEnv(t *testing.T) {
 		})
 	}
 }
-
-func TestItoa(t *testing.T) {
-	tests := []struct {
-		input    int
-		expected string
-	}{
-		{0, "0"},
-		{1, "1"},
-		{-1, "-1"},
-		{123, "123"},
-		{-456, "-456"},
-		{12345, "12345"},
-	}
-
-	for _, tt := range tests {
-		result := itoa(tt.input)
-		if result != tt.expected {
-			t.Errorf("itoa(%d) = %q, want %q", tt.input, result, tt.expected)
-		}
-	}
-}


### PR DESCRIPTION
## Summary

Fourth simplification pass — removes dead exports/types and replaces hand-rolled helpers. 9 files changed, +3/-198 lines (net -195).

### Dead code removal
- Remove dead types: `SettingsHooks`, `SettingsHookEntry`, `HookConfig` from hooks/types.go
- Remove dead exports: `Colors`, `GenerateFull` from identity package
- Remove dead exports: `LogPostCreated`, `LogFeedRead`, `DetectCallerAgent` from logging package
- Remove associated tests for all deleted functions

### Cleanup
- Replace hand-rolled `itoa` (22 lines) with `strconv.Itoa` in logging/context.go
- Widen `formatSuggestPost` param from `*os.File` to `io.Writer` in cli/suggest.go

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] Pre-commit hooks pass
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)